### PR TITLE
Write measurement sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently in heavy development. Major milestones are listed below:
   - [x] Reading and writing RTS, AOcal and hyperdrive style calibration
     solutions
   - [x] Writing visibilities to uvfits
-  - [ ] Writing visibilities to measurement sets
+- [x] Writing visibilities to measurement sets
   - [ ] Writing to multiple uvfits or measurement sets for each MWA coarse channel
   - [ ] Direction-dependent calibration
 

--- a/README.md
+++ b/README.md
@@ -15,33 +15,35 @@ Aims to provide feature parity with and exceed the MWA Real-Time System (RTS).
 
 Currently in heavy development. Major milestones are listed below:
 
-  - [x] Direction-independent calibration (on both CPUs and GPUs)
-  - [x] Reading visibilities from raw MWA data (legacy and MWAX), uvfits and
-    measurement sets
-  - [x] Reading and writing RTS, AOcal and WODEN style sky-model source lists
-  - [x] Reading and writing RTS, AOcal and hyperdrive style calibration
-    solutions
-  - [x] Writing visibilities to uvfits
+- [x] Direction-independent calibration (on both CPUs and GPUs)
+- [x] Reading visibilities from raw MWA data (legacy and MWAX), uvfits and
+      measurement sets
+- [x] Reading and writing RTS, AOcal and WODEN style sky-model source lists
+- [x] Reading and writing RTS, AOcal and hyperdrive style calibration
+      solutions
+- [x] Writing visibilities to uvfits
 - [x] Writing visibilities to measurement sets
-  - [ ] Writing to multiple uvfits or measurement sets for each MWA coarse channel
-  - [ ] Direction-dependent calibration
+- [ ] Writing to multiple uvfits or measurement sets for each MWA coarse channel
+- [ ] Direction-dependent calibration
 
 ## Usage
+
 A comprehensive use guide can be found on the [wiki](https://github.com/MWATelescope/mwa_hyperdrive/wiki), but below are some TL;DR examples.
 
 Many `hyperdrive` functions require the beam code to function. The MWA
 FEE beam HDF5 file can be obtained with:
 
-  `wget http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5`
+`wget http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5`
 
 Move the `h5` file anywhere you like, and put the file path in `MWA_BEAM_FILE`:
 
-  `export MWA_BEAM_FILE=/path/to/mwa_full_embedded_element_pattern.h5`
+`export MWA_BEAM_FILE=/path/to/mwa_full_embedded_element_pattern.h5`
 
 See the README for [`hyperbeam`](https://github.com/MWATelescope/mwa_hyperbeam)
 for more info.
 
 ### DI Calibration
+
 <details>
 By default, only calibration solutions are written out (to a default filename):
 
@@ -84,6 +86,7 @@ or to a target resolution:
 </details>
 
 ### Source lists
+
 <details>
 A number of sky-model source list utilities are available. At the time of
 writing, the following subcommands are available (output edited for clarity):
@@ -115,9 +118,11 @@ pointing and target frequencies (determined by a metafits file):
                -m *.metafits \
                -n 1000 \
                srclist_1000.yaml
+
 </details>
 
 ### Visibility Simulation
+
 <details>
 
 `hyperdrive` can generate visibilities from a sky-model source list (output
@@ -137,12 +142,15 @@ also available):
                --filter-points \
                --filter-shapelets \
                -o model_gaussians.uvfits
+
 </details>
 
 ## Installation
+
 <details>
 
 ### Prerequisites
+
 <details>
 
 - An NVIDIA GPU with compute capability >=2. See this
@@ -154,6 +162,7 @@ also available):
   `https://www.rust-lang.org/tools/install`
 
 - [cfitsio](https://heasarc.gsfc.nasa.gov/docs/software/fitsio/)
+
   - Can compile statically; use the `cfitsio-static` or `all-static` features.
   - Ubuntu: `libcfitsio-dev`
   - Arch: `cfitsio`
@@ -162,6 +171,7 @@ also available):
     - If not specified, `pkg-config` is used to find the library.
 
 - [ERFA](https://github.com/liberfa/erfa)
+
   - Can compile statically; use the `erfa-static` or `all-static` features.
     - Requires a C compiler and `autoconf`.
   - Ubuntu: `liberfa-dev`
@@ -180,13 +190,14 @@ also available):
 #### Optional dependencies
 
 - [CUDA](https://developer.nvidia.com/cuda-zone)
+
   - Only needed if either the `cuda` or `cuda-single` feature is enabled
   - Can link statically; use the `cuda-static` or `all-static` features.
   - Arch: `cuda`
   - The library dir can be specified manually with `CUDA_LIB`
     - If not specified, `/usr/local/cuda` and `/opt/cuda` are searched.
 
-- Calibration solutions plotting 
+- Calibration solutions plotting
   - Only needed if the `plotting` feature is enabled (which it is by default)
   - Arch: `pkg-config` `make` `cmake` `freetype2`
   - Ubuntu: `libfreetype-dev` `libexpat1-dev`
@@ -200,39 +211,39 @@ link all libraries statically, use `PKG_CONFIG_ALL_STATIC=1`.
 
 - Specify your GPU's compute capability
 
-    Export the `HYPERDRIVE_CUDA_COMPUTE` environment variable with your
-    compute-capability number, e.g.
+  Export the `HYPERDRIVE_CUDA_COMPUTE` environment variable with your
+  compute-capability number, e.g.
 
-    `export HYPERDRIVE_CUDA_COMPUTE=75`
+  `export HYPERDRIVE_CUDA_COMPUTE=75`
 
 - Compile the source
 
-    `cargo install --path . --locked`
+  `cargo install --path . --locked`
 
-    To enable CUDA functionality, add `--features=cuda` or
-    `--features=cuda-single` to the above command. If you're using a desktop
-    NVIDIA GPU, you probably want the `cuda-single` feature.
+  To enable CUDA functionality, add `--features=cuda` or
+  `--features=cuda-single` to the above command. If you're using a desktop
+  NVIDIA GPU, you probably want the `cuda-single` feature.
 
-    You may need to specify additional compiler options, depending on your
-    setup. For example, CUDA can only use certain versions of GCC, so the
-    following might be needed before running `cargo install`:
+  You may need to specify additional compiler options, depending on your
+  setup. For example, CUDA can only use certain versions of GCC, so the
+  following might be needed before running `cargo install`:
 
-    `export CXX=/usr/bin/g++-5`
+  `export CXX=/usr/bin/g++-5`
 
-    It's also possible to specify environment variables temporarily:
+  It's also possible to specify environment variables temporarily:
 
-    `CXX=/usr/bin/g++-5 HYPERDRIVE_CUDA_COMPUTE=75 cargo install --path . --locked`
+  `CXX=/usr/bin/g++-5 HYPERDRIVE_CUDA_COMPUTE=75 cargo install --path . --locked`
 
 - Run the compiled binary (you may need to include it in your `PATH`; see the
   output of `cargo install`)
 
-    `hyperdrive -h`
+  `hyperdrive -h`
 
-    A number of subcommands should present themselves, and the help text for
-    each subcommand should clarify usage.
+  A number of subcommands should present themselves, and the help text for
+  each subcommand should clarify usage.
 
-    On the same system, the `hyperdrive` binary can be copied and used
-    anywhere you like!
+  On the same system, the `hyperdrive` binary can be copied and used
+  anywhere you like!
 
 </details>
 
@@ -247,8 +258,9 @@ Report the version of the software used, your usage and the program output in a
 new GitHub issue.
 
 ## FAQ
+
 - Naming convention
 
-    This project is called `mwa_hyperdrive` so that it cannot be confused with
-    other projects involving the word `hyperdrive`, but the binary is called
-    `hyperdrive` to help users' fingers.
+  This project is called `mwa_hyperdrive` so that it cannot be confused with
+  other projects involving the word `hyperdrive`, but the binary is called
+  `hyperdrive` to help users' fingers.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -534,7 +534,6 @@ fn calibrate_benchmarks(c: &mut Criterion) {
 
     let vis_shape = (num_timesteps, num_baselines, num_chanblocks);
     let vis_data: Array3<Jones<f32>> = Array3::from_elem(vis_shape, Jones::identity() * 4.0);
-    let vis_weights: Array3<f32> = Array3::ones(vis_shape);
     let vis_model: Array3<Jones<f32>> = Array3::from_elem(vis_shape, Jones::identity());
     let baseline_weights = vec![1.0; num_baselines];
 
@@ -544,7 +543,6 @@ fn calibrate_benchmarks(c: &mut Criterion) {
             b.iter(|| {
                 calibrate_timeblocks(
                     vis_data.view(),
-                    vis_weights.view(),
                     vis_model.view(),
                     &timeblocks,
                     &chanblocks,

--- a/src/calibrate/args.rs
+++ b/src/calibrate/args.rs
@@ -53,7 +53,7 @@ lazy_static::lazy_static! {
     static ref DI_CALIBRATE_OUTPUT_HELP: String =
         format!("Paths to the calibration output files. Supported calibrated visibility outputs: {}. Supported calibration solution formats: {}. Default: {}", *VIS_OUTPUT_EXTENSIONS, *CAL_SOLUTION_EXTENSIONS, DEFAULT_OUTPUT_SOLUTIONS_FILENAME);
 
-    static ref MODEL_FILENAME_HELP: String = format!("The path to the file where the generated sky-model visibilities are written. If this argument isn't supplied, then no file is written. Supported formats: {}", *VIS_OUTPUT_EXTENSIONS);
+    static ref MODEL_FILENAME_HELP: String = format!("The path to the file where the generated sky-model visibilities are written. If this argument isn't supplied, then no file is written. Supported formats: uvfits");
 
     static ref SOURCE_LIST_TYPE_HELP: String =
         format!("The type of sky-model source list. Valid types are: {}. If not specified, all types are attempted", *mwa_hyperdrive_srclist::SOURCE_LIST_TYPES_COMMA_SEPARATED);

--- a/src/calibrate/args.rs
+++ b/src/calibrate/args.rs
@@ -108,11 +108,6 @@ pub struct CalibrateUserArgs {
     #[clap(short, long, help = MODEL_FILENAME_HELP.as_str(), help_heading = "OUTPUT FILES")]
     pub model_filename: Option<PathBuf>,
 
-    /// When writing out calibrated visibilities, don't include
-    /// auto-correlations.
-    #[clap(long, help_heading = "OUTPUT FILES")]
-    pub ignore_autos: bool,
-
     /// When writing out calibrated visibilities, average this many timesteps
     /// together. Also supports a target time resolution (e.g. 8s). The value
     /// must be a multiple of the input data's time resolution. The default is
@@ -350,7 +345,6 @@ impl CalibrateUserArgs {
                 source_list_type,
                 outputs,
                 model_filename,
-                ignore_autos,
                 output_vis_time_average,
                 output_vis_freq_average,
                 num_sources,
@@ -389,7 +383,6 @@ impl CalibrateUserArgs {
                 source_list_type: cli_args.source_list_type.or(source_list_type),
                 outputs: cli_args.outputs.or(outputs),
                 model_filename: cli_args.model_filename.or(model_filename),
-                ignore_autos: cli_args.ignore_autos || ignore_autos,
                 output_vis_time_average: cli_args
                     .output_vis_time_average
                     .or(output_vis_time_average),

--- a/src/calibrate/di/code/mod.rs
+++ b/src/calibrate/di/code/mod.rs
@@ -746,12 +746,12 @@ pub fn calibrate_timeblocks<'a>(
             ((total_converged_count as f64 / num_chanblocks as f64) * 100.0).round()
         );
 
-        // Calibrate each timeblock individually.
-        let mut all_cal_results = vec![];
+        // Calibrate each timeblock individually. Set all solutions to be that
+        // of the averaged solutions so that the individual timeblocks have less
+        // work to do.
+        di_jones.accumulate_axis_inplace(Axis(0), |&prev, curr| *curr = prev);
+        let mut all_cal_results = Vec::with_capacity(timeblocks.len());
         for (i_timeblock, timeblock) in timeblocks.iter().enumerate() {
-            // Set all solutions to be that of the averaged solutions.
-            di_jones.accumulate_axis_inplace(Axis(1), |&prev, curr| *curr = prev);
-
             let pb = make_calibration_progress_bar(
                 num_chanblocks,
                 format!(

--- a/src/calibrate/di/mod.rs
+++ b/src/calibrate/di/mod.rs
@@ -240,7 +240,8 @@ pub(crate) fn di_calibrate(
                         Some(gpst) => Epoch::from_gpst_seconds(gpst as f64),
                         None => start_timestamp,
                     };
-                    let sched_duration = *obs_context.timestamps.last() - sched_start_timestamp;
+                    let sched_duration =
+                        *obs_context.timestamps.last() + int_time - sched_start_timestamp;
 
                     let marlu_obs_ctx = MarluObsContext {
                         sched_start_timestamp,

--- a/src/calibrate/di/mod.rs
+++ b/src/calibrate/di/mod.rs
@@ -12,7 +12,6 @@ pub(crate) mod code;
 pub use code::calibrate_timeblocks;
 use code::*;
 
-use hifitime::{Duration, Unit};
 use itertools::izip;
 use log::{debug, info, log_enabled, trace, Level::Debug};
 use marlu::{
@@ -25,10 +24,7 @@ use rayon::prelude::*;
 use super::{params::CalibrateParams, solutions::CalibrationSolutions, CalibrateError};
 use crate::data_formats::VisOutputType;
 use mwa_hyperdrive_common::{
-    hifitime::{self, Epoch},
-    itertools, log, marlu, ndarray,
-    num_traits::Zero,
-    rayon,
+    hifitime::Epoch, itertools, log, marlu, ndarray, num_traits::Zero, rayon,
 };
 
 /// Do all the steps required for direction-independent calibration; read the
@@ -176,7 +172,7 @@ pub(crate) fn di_calibrate(
         }
 
         let ant_pairs: Vec<(usize, usize)> = params.get_ant_pairs();
-        let int_time: Duration = Duration::from_f64(obs_context.time_res.unwrap(), Unit::Second);
+        let int_time = obs_context.guess_time_res();
 
         let start_timestamp = obs_context.timestamps[params.timesteps[0]];
 
@@ -187,7 +183,7 @@ pub(crate) fn di_calibrate(
             int_time,
             num_sel_chans: obs_context.fine_chan_freqs.len(),
             start_freq_hz: obs_context.fine_chan_freqs[0] as f64,
-            freq_resolution_hz: obs_context.freq_res.unwrap(),
+            freq_resolution_hz: obs_context.guess_freq_res(),
             sel_baselines: ant_pairs,
             avg_time: params.output_vis_time_average_factor,
             avg_freq: params.output_vis_freq_average_factor,

--- a/src/calibrate/di/mod.rs
+++ b/src/calibrate/di/mod.rs
@@ -164,11 +164,6 @@ pub(crate) fn di_calibrate(
 
         info!("Writing visibilities...");
 
-        // TODO(dev): support and test autos
-        if params.using_autos {
-            panic!("not supperted yet... or are they?");
-        }
-
         let ant_pairs: Vec<(usize, usize)> = params.get_ant_pairs();
         let int_time: Duration = Duration::from_f64(obs_context.time_res.unwrap(), Unit::Second);
 

--- a/src/calibrate/error.rs
+++ b/src/calibrate/error.rs
@@ -4,7 +4,7 @@
 
 //! Error type for all calibration-related errors.
 
-use marlu::io::error::{IOError as MarluIOError, UvfitsWriteError};
+use marlu::io::error::{IOError as MarluIOError, MeasurementSetWriteError, UvfitsWriteError};
 use mwalib::fitsio;
 use thiserror::Error;
 
@@ -55,6 +55,9 @@ pub enum CalibrateError {
 
     #[error("Error when writing uvfits: {0}")]
     UviftsWrite(#[from] UvfitsWriteError),
+
+    #[error("Error when writing measurement set: {0}")]
+    MeasurementSetWrite(#[from] MeasurementSetWriteError),
 
     #[error("Error when using Marlu for IO: {0}")]
     MarluIO(#[from] MarluIOError),

--- a/src/calibrate/params/mod.rs
+++ b/src/calibrate/params/mod.rs
@@ -1362,7 +1362,7 @@ fn can_write_to_file(file: &Path) -> Result<(), InvalidArgsError> {
                 warn!("Will overwrite the existing file '{}'", file.display())
             } else {
                 // file didn't exist before, remove.
-                fs::remove_file(file).map_err(InvalidArgsError::IO)?;
+                std::fs::remove_file(file).map_err(InvalidArgsError::IO)?;
             }
         }
 

--- a/src/calibrate/params/mod.rs
+++ b/src/calibrate/params/mod.rs
@@ -1360,6 +1360,9 @@ fn can_write_to_file(file: &Path) -> Result<(), InvalidArgsError> {
         Ok(_) => {
             if file_exists {
                 warn!("Will overwrite the existing file '{}'", file.display())
+            } else {
+                // file didn't exist before, remove.
+                fs::remove_file(file).map_err(InvalidArgsError::IO)?;
             }
         }
 

--- a/src/calibrate/params/mod.rs
+++ b/src/calibrate/params/mod.rs
@@ -804,44 +804,38 @@ impl CalibrateParams {
             } else {
                 // Parse and verify user input (specified resolutions must
                 // evenly divide the input data's resolutions).
-                let time_factor = parse_time_average_factor(
-                    obs_context
-                        .time_res
-                        .map(|res| res * time_average_factor as f64),
-                    output_vis_time_average,
-                    1,
-                )
-                .map_err(|e| match e {
-                    AverageFactorError::Zero => InvalidArgsError::OutputVisTimeAverageFactorZero,
-                    AverageFactorError::NotInteger => {
-                        InvalidArgsError::OutputVisTimeFactorNotInteger
-                    }
-                    AverageFactorError::NotIntegerMultiple { out, inp } => {
-                        InvalidArgsError::OutputVisTimeResNotMulitple { out, inp }
-                    }
-                    AverageFactorError::Parse(e) => {
-                        InvalidArgsError::ParseOutputVisTimeAverageFactor(e)
-                    }
-                })?;
-                let freq_factor = parse_freq_average_factor(
-                    obs_context
-                        .freq_res
-                        .map(|res| res * freq_average_factor as f64),
-                    output_vis_freq_average,
-                    1,
-                )
-                .map_err(|e| match e {
-                    AverageFactorError::Zero => InvalidArgsError::OutputVisFreqAverageFactorZero,
-                    AverageFactorError::NotInteger => {
-                        InvalidArgsError::OutputVisFreqFactorNotInteger
-                    }
-                    AverageFactorError::NotIntegerMultiple { out, inp } => {
-                        InvalidArgsError::OutputVisFreqResNotMulitple { out, inp }
-                    }
-                    AverageFactorError::Parse(e) => {
-                        InvalidArgsError::ParseOutputVisFreqAverageFactor(e)
-                    }
-                })?;
+                let time_factor =
+                    parse_time_average_factor(obs_context.time_res, output_vis_time_average, 1)
+                        .map_err(|e| match e {
+                            AverageFactorError::Zero => {
+                                InvalidArgsError::OutputVisTimeAverageFactorZero
+                            }
+                            AverageFactorError::NotInteger => {
+                                InvalidArgsError::OutputVisTimeFactorNotInteger
+                            }
+                            AverageFactorError::NotIntegerMultiple { out, inp } => {
+                                InvalidArgsError::OutputVisTimeResNotMulitple { out, inp }
+                            }
+                            AverageFactorError::Parse(e) => {
+                                InvalidArgsError::ParseOutputVisTimeAverageFactor(e)
+                            }
+                        })?;
+                let freq_factor =
+                    parse_freq_average_factor(obs_context.freq_res, output_vis_freq_average, 1)
+                        .map_err(|e| match e {
+                            AverageFactorError::Zero => {
+                                InvalidArgsError::OutputVisFreqAverageFactorZero
+                            }
+                            AverageFactorError::NotInteger => {
+                                InvalidArgsError::OutputVisFreqFactorNotInteger
+                            }
+                            AverageFactorError::NotIntegerMultiple { out, inp } => {
+                                InvalidArgsError::OutputVisFreqResNotMulitple { out, inp }
+                            }
+                            AverageFactorError::Parse(e) => {
+                                InvalidArgsError::ParseOutputVisFreqAverageFactor(e)
+                            }
+                        })?;
 
                 (time_factor, freq_factor)
             };

--- a/src/calibrate/params/tests.rs
+++ b/src/calibrate/params/tests.rs
@@ -383,16 +383,20 @@ fn test_handle_bad_array_pos() {
 }
 
 #[test]
-/// test that it correctly stacks averaging factor.
+/// Test that the input visibility frequency average factor stacks with the
+/// output frequency averaging factor.
 ///
-/// TODO(dev): use test data with multiple timesteps to test time factor stacking
+/// TODO(dev): use test data with multiple timesteps to test time factor
+/// stacking
 fn test_handle_both_vis_avg() {
     let mut args = get_reduced_1090008640(true);
+    // The input data is 40kHz; input is averaged 2x
     args.freq_average_factor = Some("80kHz".into());
+    // Output is averaged 2x from the averaged input; a total of 4.
     args.output_vis_freq_average = Some("160kHz".into());
     args.outputs = Some(vec!["test.uvfits".into()]);
     let result = args.into_params().unwrap();
 
-    // output averaging factor should be relative to cal averaging factor.
-    assert_eq!(result.output_vis_freq_average_factor, 2);
+    // output averaging factor is relative to the input frequency resolution.
+    assert_eq!(result.output_vis_freq_average_factor, 4);
 }

--- a/src/context/helpers.rs
+++ b/src/context/helpers.rs
@@ -1,0 +1,27 @@
+use mwa_hyperdrive_common::{
+    hifitime::{Duration, Epoch, Unit},
+    itertools::Itertools,
+    lazy_static,
+};
+
+lazy_static::lazy_static! {
+    static ref DURATION_MAX: Duration = Duration::from_f64(f64::MAX, Unit::Second);
+}
+
+pub fn guess_time_res(timestamps: Vec<Epoch>) -> Option<Duration> {
+    timestamps
+        .iter()
+        .tuple_windows()
+        .fold(None, |result, (&past, &future)| {
+            Some(result.unwrap_or(*DURATION_MAX).min(future - past))
+        })
+}
+
+pub fn guess_freq_res(frequencies: Vec<f64>) -> Option<f64> {
+    frequencies
+        .iter()
+        .tuple_windows()
+        .fold(None, |result, (&low, &high)| {
+            Some(result.unwrap_or(f64::MAX).min(high - low))
+        })
+}

--- a/src/context/helpers.rs
+++ b/src/context/helpers.rs
@@ -1,3 +1,5 @@
+use std::ops::Sub;
+
 use mwa_hyperdrive_common::{
     hifitime::{Duration, Epoch, Unit},
     itertools::Itertools,
@@ -8,20 +10,22 @@ lazy_static::lazy_static! {
     static ref DURATION_MAX: Duration = Duration::from_f64(f64::MAX, Unit::Second);
 }
 
-pub fn guess_time_res(timestamps: Vec<Epoch>) -> Option<Duration> {
-    timestamps
+pub fn guess_interval<T, O>(elements: &[T]) -> Option<O>
+where
+    T: Sub<Output = O> + Copy,
+    O: PartialOrd,
+{
+    elements
         .iter()
         .tuple_windows()
-        .fold(None, |result, (&past, &future)| {
-            Some(result.unwrap_or(*DURATION_MAX).min(future - past))
-        })
+        .map(|(&a, &b)| b.sub(a))
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+}
+
+pub fn guess_time_res(timestamps: Vec<Epoch>) -> Option<Duration> {
+    guess_interval(&timestamps)
 }
 
 pub fn guess_freq_res(frequencies: Vec<f64>) -> Option<f64> {
-    frequencies
-        .iter()
-        .tuple_windows()
-        .fold(None, |result, (&low, &high)| {
-            Some(result.unwrap_or(f64::MAX).min(high - low))
-        })
+    guess_interval(&frequencies)
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -68,11 +68,11 @@ pub struct ObsContext {
     /// The [XyzGeodetic] coordinates of all tiles in the array (all coordinates
     /// are specified in \[metres\]). This includes tiles that have been flagged
     /// in the input data.
-    pub(crate) tile_xyzs: Vec1<XyzGeodetic>,
+    pub tile_xyzs: Vec1<XyzGeodetic>,
 
     /// The flagged tiles, either already missing data or suggested to be
     /// flagged. Zero indexed.
-    pub(crate) flagged_tiles: Vec<usize>,
+    pub flagged_tiles: Vec<usize>,
 
     /// Are auto-correlations present in the visibility data?
     pub(crate) _autocorrelations_present: bool,
@@ -121,7 +121,7 @@ pub struct ObsContext {
 
     /// The flagged fine channels for each baseline in the supplied data. Zero
     /// indexed.
-    pub(crate) flagged_fine_chans: Vec<usize>,
+    pub flagged_fine_chans: Vec<usize>,
 
     /// The fine channels per coarse channel already flagged in the supplied
     /// data. Zero indexed.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -19,15 +19,15 @@ use mwa_hyperdrive_common::{hifitime, marlu, ndarray, vec1};
 ///
 /// Tile information is ordered according to the "Antenna" column in HDU 1 of
 /// the observation's metafits file.
-pub(crate) struct ObsContext {
+pub struct ObsContext {
     /// The observation ID, which is also the observation's scheduled start GPS
     /// time (but shouldn't be used for this purpose).
-    pub(crate) obsid: Option<u32>,
+    pub obsid: Option<u32>,
 
     /// The unique timestamps in the observation. These are stored as `hifitime`
     /// [Epoch] structs to help keep the code flexible. These include timestamps
     /// that are deemed "flagged" by the observation.
-    pub(crate) timestamps: Vec1<Epoch>,
+    pub timestamps: Vec1<Epoch>,
 
     /// The *available* timestep indices of the input data. This does not
     /// necessarily start at 0, and is not necessarily regular (e.g. a valid
@@ -37,7 +37,7 @@ pub(crate) struct ObsContext {
     /// data that also isn't regular; naively reading in a dataset with 2
     /// timesteps that are separated by more than the time resolution of the
     /// data would give misleading results.
-    pub(crate) all_timesteps: Vec1<usize>,
+    pub all_timesteps: Vec1<usize>,
 
     /// The timestep indices of the input data that aren't totally flagged.
     ///
@@ -107,7 +107,7 @@ pub(crate) struct ObsContext {
     ///
     /// These are kept as ints to help some otherwise error-prone calculations
     /// using floats. By using ints, we assume there is no sub-Hz structure.
-    pub(crate) fine_chan_freqs: Vec1<u64>,
+    pub fine_chan_freqs: Vec1<u64>,
 
     /// The flagged fine channels for each baseline in the supplied data. Zero
     /// indexed.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -65,7 +65,7 @@ pub(crate) struct ObsContext {
     pub(crate) flagged_tiles: Vec<usize>,
 
     /// Are auto-correlations present in the visibility data?
-    pub(crate) autocorrelations_present: bool,
+    pub(crate) _autocorrelations_present: bool,
 
     /// The dipole gains for each tile in the array. The first axis is unflagged
     /// antenna, the second dipole index. These will typically all be of value

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -1,0 +1,94 @@
+use crate::context::ObsContext;
+use birli::marlu::{RADec, XyzGeodetic};
+use mwa_hyperdrive_common::{
+    hifitime::{Duration, Epoch, Unit},
+    vec1::vec1,
+};
+
+fn get_minimal_obs_context() -> ObsContext {
+    ObsContext {
+        obsid: None,
+        timestamps: vec1![Epoch::from_gpst_seconds(1090008640.0)],
+        all_timesteps: vec1![0],
+        unflagged_timesteps: vec![0],
+        phase_centre: RADec::default(),
+        pointing_centre: Some(RADec::default()),
+        tile_names: vec1!["Tile00".into()],
+        tile_xyzs: vec1![XyzGeodetic::default()],
+        flagged_tiles: vec![],
+        autocorrelations_present: false,
+        dipole_gains: None,
+        time_res: None,
+        array_position: None,
+        coarse_chan_nums: vec![],
+        coarse_chan_freqs: vec![],
+        num_fine_chans_per_coarse_chan: 1,
+        freq_res: None,
+        fine_chan_freqs: vec1![128_000_000],
+        flagged_fine_chans: vec![],
+        flagged_fine_chans_per_coarse_chan: vec![],
+    }
+}
+
+#[test]
+pub fn test_guess_time_res() {
+    let mut obs_ctx = get_minimal_obs_context();
+
+    // test fallback to 1s
+    obs_ctx.time_res = None;
+    obs_ctx.timestamps = vec1![Epoch::from_gpst_seconds(1090000000.0)];
+
+    assert_eq!(
+        obs_ctx.guess_time_res(),
+        Duration::from_f64(1., Unit::Second)
+    );
+
+    // test use min delta
+    obs_ctx.time_res = None;
+    obs_ctx.timestamps = vec1![
+        Epoch::from_gpst_seconds(1090000000.0),
+        Epoch::from_gpst_seconds(1090000010.0),
+        Epoch::from_gpst_seconds(1090000013.0),
+    ];
+
+    assert_eq!(
+        obs_ctx.guess_time_res(),
+        Duration::from_f64(3., Unit::Second)
+    );
+
+    // test use direct time_res over min_delta
+    obs_ctx.time_res = Some(2.);
+    obs_ctx.timestamps = vec1![
+        Epoch::from_gpst_seconds(1090000000.0),
+        Epoch::from_gpst_seconds(1090000010.0),
+        Epoch::from_gpst_seconds(1090000013.0),
+    ];
+
+    assert_eq!(
+        obs_ctx.guess_time_res(),
+        Duration::from_f64(2., Unit::Second)
+    );
+}
+
+#[test]
+pub fn test_guess_freq_res() {
+    let mut obs_ctx = get_minimal_obs_context();
+
+    // test fallback to 1s
+    obs_ctx.freq_res = None;
+    obs_ctx.fine_chan_freqs = vec1![128_000_000];
+
+    assert_eq!(obs_ctx.guess_freq_res(), 10_000.);
+
+    // test use min delta
+    obs_ctx.freq_res = None;
+    obs_ctx.fine_chan_freqs = vec1![128_000_000, 128_100_000, 128_120_000];
+
+    assert_eq!(obs_ctx.guess_freq_res(), 20_000.);
+
+    // test use direct freq_res over min_delta
+    obs_ctx.freq_res = Some(30_000.);
+    obs_ctx.fine_chan_freqs = vec1![128_000_000, 128_100_000, 128_120_000];
+
+    assert_eq!(obs_ctx.guess_freq_res(), 30_000.);
+}

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -16,7 +16,7 @@ fn get_minimal_obs_context() -> ObsContext {
         tile_names: vec1!["Tile00".into()],
         tile_xyzs: vec1![XyzGeodetic::default()],
         flagged_tiles: vec![],
-        autocorrelations_present: false,
+        _autocorrelations_present: false,
         dipole_gains: None,
         time_res: None,
         array_position: None,

--- a/src/data_formats/mod.rs
+++ b/src/data_formats/mod.rs
@@ -12,9 +12,9 @@ mod uvfits;
 
 pub(crate) use error::ReadInputDataError;
 pub use metafits::*;
-pub(crate) use ms::{MsReadError, MS};
+pub use ms::{MsReadError, MS};
 pub(crate) use raw::{RawDataReader, RawReadError};
-pub(crate) use uvfits::{UvfitsReadError, UvfitsReader};
+pub use uvfits::{UvfitsReadError, UvfitsReader};
 
 use std::collections::{HashMap, HashSet};
 
@@ -27,7 +27,7 @@ use crate::context::ObsContext;
 use mwa_hyperdrive_common::{marlu, ndarray, vec1};
 
 #[derive(Debug)]
-pub(crate) enum VisInputType {
+pub enum VisInputType {
     Raw,
     MeasurementSet,
     Uvfits,
@@ -37,9 +37,11 @@ pub(crate) enum VisInputType {
 pub(crate) enum VisOutputType {
     #[strum(serialize = "uvfits")]
     Uvfits,
+    #[strum(serialize = "ms")]
+    MeasurementSet,
 }
 
-pub(crate) trait InputData: Sync + Send {
+pub trait InputData: Sync + Send {
     fn get_obs_context(&self) -> &ObsContext;
 
     fn get_input_data_type(&self) -> VisInputType;

--- a/src/data_formats/ms/mod.rs
+++ b/src/data_formats/ms/mod.rs
@@ -32,7 +32,7 @@ use crate::{context::ObsContext, data_formats::metafits, time::round_hundredths_
 use mwa_hyperdrive_beam::Delays;
 use mwa_hyperdrive_common::{hifitime, log, marlu, mwalib, ndarray};
 
-pub(crate) struct MS {
+pub struct MS {
     /// Input data metadata.
     obs_context: ObsContext,
 
@@ -59,7 +59,7 @@ impl MS {
     /// The measurement set is expected to be formatted in the way that
     /// cotter/Birli write measurement sets.
     // TODO: Handle multiple measurement sets.
-    pub(crate) fn new<P: AsRef<Path>, P2: AsRef<Path>>(
+    pub fn new<P: AsRef<Path>, P2: AsRef<Path>>(
         ms: P,
         metafits: Option<P2>,
         dipole_delays: &mut Delays,

--- a/src/data_formats/ms/mod.rs
+++ b/src/data_formats/ms/mod.rs
@@ -558,7 +558,7 @@ impl MS {
                 tile_names,
                 tile_xyzs,
                 flagged_tiles,
-                autocorrelations_present,
+                _autocorrelations_present: autocorrelations_present,
                 dipole_gains,
                 time_res,
                 // XXX(Dev): no way to get array_pos from MS AFAIK

--- a/src/data_formats/ms/tests.rs
+++ b/src/data_formats/ms/tests.rs
@@ -5,6 +5,9 @@
 use std::collections::HashSet;
 
 use approx::assert_abs_diff_eq;
+use birli::marlu::XyzGeodetic;
+use marlu::{Jones, MeasurementSetWriter, ObsContext as MarluObsContext, VisContext, VisWritable};
+use mwa_hyperdrive_common::hifitime::{Duration, Unit};
 use serial_test::serial; // Need to test serially because casacore is a steaming pile.
 use tempfile::tempdir;
 
@@ -101,4 +104,97 @@ fn test_1090008640_calibration_quality() {
 
     let cal_vis = get_cal_vis(&params, false).expect("Couldn't read data and generate a model");
     test_1090008640_quality(params, cal_vis);
+}
+
+#[test]
+fn test_timestep_reading() {
+    let temp_dir = tempdir().expect("Couldn't make temp dir").into_path();
+    let vis_path = temp_dir.join("vis.ms");
+
+    let num_timesteps = 10;
+    let num_channels = 10;
+    let ant_pairs = vec![(0, 1), (0, 2), (1, 2)];
+
+    let obsid = 1090000000;
+
+    let vis_ctx = VisContext {
+        num_sel_timesteps: num_timesteps,
+        start_timestamp: Epoch::from_gpst_seconds(obsid as f64),
+        int_time: Duration::from_f64(1., Unit::Second),
+        num_sel_chans: num_channels,
+        start_freq_hz: 128_000_000.,
+        freq_resolution_hz: 10_000.,
+        sel_baselines: ant_pairs,
+        avg_time: 1,
+        avg_freq: 1,
+        num_vis_pols: 4,
+    };
+
+    let shape = vis_ctx.sel_dims();
+
+    let vis_data = Array3::<Jones<f32>>::from_shape_fn(shape, |(t, c, b)| {
+        let (ant1, ant2) = vis_ctx.sel_baselines[b];
+        Jones::from([t as f32, c as f32, ant1 as f32, ant2 as f32, 0., 0., 0., 0.])
+    });
+
+    let weight_data = Array3::<f32>::from_elem(shape, 1.);
+
+    let phase_centre = RADec::new_degrees(0., -27.);
+    let array_pos = LatLngHeight::new_mwa();
+    #[rustfmt::skip]
+    let tile_xyzs = vec![
+        XyzGeodetic { x: 0., y: 0., z: 0., },
+        XyzGeodetic { x: 1., y: 0., z: 0., },
+        XyzGeodetic { x: 0., y: 1., z: 0., },
+    ];
+    let tile_names = vec!["tile_0_0", "tile_1_0", "tile_0_1"];
+
+    let mut writer = MeasurementSetWriter::new(&vis_path, phase_centre, Some(array_pos));
+
+    let marlu_obs_ctx = MarluObsContext {
+        sched_start_timestamp: Epoch::from_gpst_seconds(obsid as f64),
+        sched_duration: ((num_timesteps + 1) as f64 * vis_ctx.int_time),
+        name: Some(format!("MWA obsid {}", obsid)),
+        phase_centre,
+        pointing_centre: Some(phase_centre),
+        array_pos,
+        ant_positions_enh: tile_xyzs
+            .iter()
+            .map(|xyz| xyz.to_enh(array_pos.latitude_rad))
+            .collect(),
+        ant_names: tile_names.iter().map(|&s| String::from(s)).collect(),
+        field_name: None,
+        project_id: None,
+        observer: None,
+    };
+
+    writer.initialize(&vis_ctx, &marlu_obs_ctx).unwrap();
+
+    writer
+        .write_vis_marlu(
+            vis_data.view(),
+            weight_data.view(),
+            &vis_ctx,
+            &tile_xyzs,
+            false,
+        )
+        .unwrap();
+
+    let ms_reader = MS::new::<&PathBuf, &PathBuf>(&vis_path, None, &mut Delays::None).unwrap();
+    let ms_ctx = ms_reader.get_obs_context();
+
+    let expected_timestamps = (0..num_timesteps)
+        .map(|t| Epoch::from_gpst_seconds((obsid + t) as f64 + 0.5))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ms_ctx
+            .timestamps
+            .iter()
+            .map(|t| t.as_gpst_seconds())
+            .collect::<Vec<_>>(),
+        expected_timestamps
+            .iter()
+            .map(|t| t.as_gpst_seconds())
+            .collect::<Vec<_>>()
+    );
 }

--- a/src/data_formats/raw/mod.rs
+++ b/src/data_formats/raw/mod.rs
@@ -366,7 +366,7 @@ impl RawDataReader {
             tile_names,
             tile_xyzs,
             flagged_tiles,
-            autocorrelations_present: true,
+            _autocorrelations_present: true,
             dipole_gains: Some(dipole_gains),
             time_res,
             array_position: Some(LatLngHeight::new_mwa()),

--- a/src/data_formats/raw/tests.rs
+++ b/src/data_formats/raw/tests.rs
@@ -517,7 +517,7 @@ fn test_mwaf_flags() {
 
     // Iterate over the arrays, where are the differences? They should be
     // primes.
-    let num_bls = params.get_num_unflagged_baselines();
+    let num_bls = params.get_num_unflagged_cross_baselines();
     let num_freqs = params.get_obs_context().fine_chan_freqs.len();
     // Unfortunately we have to conditionally select either the auto or cross
     // visibilities.

--- a/src/data_formats/uvfits/mod.rs
+++ b/src/data_formats/uvfits/mod.rs
@@ -10,8 +10,8 @@ mod read;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use error::*;
-pub(crate) use read::*;
+pub use error::*;
+pub use read::*;
 
 use hifitime::Epoch;
 

--- a/src/data_formats/uvfits/read.rs
+++ b/src/data_formats/uvfits/read.rs
@@ -21,7 +21,7 @@ use super::*;
 use crate::{
     context::ObsContext,
     data_formats::{metafits, InputData, ReadInputDataError},
-    time::round_hundredths_of_a_second_duration,
+    time::quantize_duration,
 };
 use mwa_hyperdrive_beam::Delays;
 use mwa_hyperdrive_common::{log, marlu, mwalib, ndarray};
@@ -207,16 +207,17 @@ impl UvfitsReader {
             } else {
                 Epoch::from_jde_tai(metadata.jd_zero)
             };
+
+            // the number of nanoseconds to quantize to.
+            let q = 10_000_000.;
+
             let (all_timesteps, timestamps): (Vec<usize>, Vec<Epoch>) = metadata
                 .jd_frac_timestamps
                 .iter()
                 .enumerate()
                 .map(|(i, &frac)| {
                     let jd_offset = Duration::from_f64(frac as f64, Unit::Day);
-                    (
-                        i,
-                        jd_zero + round_hundredths_of_a_second_duration(jd_offset),
-                    )
+                    (i, jd_zero + quantize_duration(jd_offset, q))
                 })
                 .unzip();
             // TODO: Determine flagging!

--- a/src/data_formats/uvfits/read.rs
+++ b/src/data_formats/uvfits/read.rs
@@ -25,7 +25,7 @@ use crate::{
 use mwa_hyperdrive_beam::Delays;
 use mwa_hyperdrive_common::{log, marlu, mwalib, ndarray};
 
-pub(crate) struct UvfitsReader {
+pub struct UvfitsReader {
     /// Observation metadata.
     pub(super) obs_context: ObsContext,
 
@@ -48,7 +48,7 @@ impl UvfitsReader {
     ///
     /// The measurement set is expected to be formatted in the way that
     /// cotter/Birli write measurement sets.
-    pub(crate) fn new<P: AsRef<Path>, P2: AsRef<Path>>(
+    pub fn new<P: AsRef<Path>, P2: AsRef<Path>>(
         uvfits: P,
         metafits: Option<P2>,
         dipole_delays: &mut Delays,

--- a/src/data_formats/uvfits/read.rs
+++ b/src/data_formats/uvfits/read.rs
@@ -356,7 +356,7 @@ impl UvfitsReader {
                 tile_names,
                 tile_xyzs,
                 flagged_tiles,
-                autocorrelations_present: metadata.autocorrelations_present,
+                _autocorrelations_present: metadata.autocorrelations_present,
                 dipole_gains,
                 time_res,
                 // XXX(Dev): Can this be obtained from the ARRAY{X,Y,Z} keys? (geocentric, wgs84)

--- a/src/data_formats/uvfits/tests.rs
+++ b/src/data_formats/uvfits/tests.rs
@@ -402,16 +402,19 @@ fn test_timestep_reading() {
         UvfitsReader::new::<&PathBuf, &PathBuf>(&vis_path.clone(), None, &mut Delays::None)
             .unwrap();
     let uvfits_ctx = uvfits_reader.get_obs_context();
-    dbg!(&uvfits_ctx
-        .timestamps
-        .iter()
-        .map(|&t| t.as_gregorian_utc())
-        .collect::<Vec<_>>());
 
+    let expected_timestamps = (0..num_timesteps)
+        .map(|t| Epoch::from_gpst_seconds((obsid + t) as f64 + 0.5))
+        .collect::<Vec<_>>();
     assert_eq!(
-        uvfits_ctx.timestamps,
-        (0..num_timesteps)
-            .map(|t| Epoch::from_gpst_seconds((obsid + t) as f64 + 0.5))
+        uvfits_ctx
+            .timestamps
+            .iter()
+            .map(|t| t.as_gpst_seconds())
+            .collect::<Vec<_>>(),
+        expected_timestamps
+            .iter()
+            .map(|t| t.as_gpst_seconds())
             .collect::<Vec<_>>()
     );
 }

--- a/src/data_formats/uvfits/tests.rs
+++ b/src/data_formats/uvfits/tests.rs
@@ -397,10 +397,8 @@ fn test_timestep_reading() {
         .write_uvfits_antenna_table(&tile_names, &tile_xyzs)
         .unwrap();
 
-    // deleteme
-    let mut uvfits_reader =
-        UvfitsReader::new::<&PathBuf, &PathBuf>(&vis_path.clone(), None, &mut Delays::None)
-            .unwrap();
+    let uvfits_reader =
+        UvfitsReader::new::<&PathBuf, &PathBuf>(&vis_path, None, &mut Delays::None).unwrap();
     let uvfits_ctx = uvfits_reader.get_obs_context();
 
     let expected_timestamps = (0..num_timesteps)

--- a/src/data_formats/uvfits/tests.rs
+++ b/src/data_formats/uvfits/tests.rs
@@ -411,7 +411,7 @@ fn test_timestep_reading() {
     assert_eq!(
         uvfits_ctx.timestamps,
         (0..num_timesteps)
-            .map(|t| Epoch::from_gpst_seconds((obsid + t) as f64))
+            .map(|t| Epoch::from_gpst_seconds((obsid + t) as f64 + 0.5))
             .collect::<Vec<_>>()
     );
 }

--- a/src/simulate_vis/error.rs
+++ b/src/simulate_vis/error.rs
@@ -6,7 +6,7 @@
 Error type for all simulate-vis-related errors.
  */
 
-use marlu::{io::error::IOError as MarluIOError, UvfitsWriteError};
+use marlu::io::error::{IOError as MarluIOError, MeasurementSetWriteError, UvfitsWriteError};
 use thiserror::Error;
 
 use mwa_hyperdrive_common::{marlu, mwalib, thiserror};
@@ -62,4 +62,10 @@ pub enum SimulateVisError {
 
     #[error(transparent)]
     IO(#[from] std::io::Error),
+
+    #[error("invalid file extension of output path {path}. {message}")]
+    OutputFileExtension { path: String, message: String },
+
+    #[error("Error when writing measurement set: {0}")]
+    MeasurementSetWrite(#[from] MeasurementSetWriteError),
 }

--- a/tests/integration/calibrate/mod.rs
+++ b/tests/integration/calibrate/mod.rs
@@ -186,7 +186,7 @@ fn test_1090008640_woden() {
 
 #[test]
 #[serial]
-fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos() {
+fn test_1090008640_di_calibrate_writes_vis_uvfits() {
     let tmp_dir = TempDir::new().expect("couldn't make tmp dir").into_path();
     let args = get_reduced_1090008640(true, false);
     let data = args.data.unwrap();
@@ -202,7 +202,6 @@ fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos() {
         "--source-list", &args.source_list.unwrap(),
         "--outputs", &format!("{}", out_vis_path.display()),
         "--model-filename", &format!("{}", cal_model.display()),
-        "--ignore-autos",
     ]);
 
     // Run di-cal and check that it succeeds
@@ -222,12 +221,6 @@ fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos() {
         gcount.parse::<usize>().unwrap(),
         exp_timesteps * exp_baselines
     );
-    // let pcount: String = get_required_fits_key!(&mut out_vis, &hdu0, "PCOUNT").unwrap();
-    // assert_eq!(pcount.parse::<usize>().unwrap(), 5);
-    // let floats_per_pol: String = get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS2").unwrap();
-    // assert_eq!(floats_per_pol.parse::<usize>().unwrap(), 3);
-    // let num_pols: String = get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS3").unwrap();
-    // assert_eq!(num_pols.parse::<usize>().unwrap(), 4);
     let num_fine_freq_chans: String =
         get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS4").unwrap();
     assert_eq!(num_fine_freq_chans.parse::<usize>().unwrap(), exp_channels);
@@ -235,7 +228,7 @@ fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos() {
 
 #[test]
 #[serial]
-fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos_avg_freq() {
+fn test_1090008640_di_calibrate_writes_vis_uvfits_avg_freq() {
     let tmp_dir = TempDir::new().expect("couldn't make tmp dir").into_path();
     let args = get_reduced_1090008640(true, false);
     let data = args.data.unwrap();
@@ -253,7 +246,6 @@ fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos_avg_freq() {
         "--source-list", &args.source_list.unwrap(),
         "--outputs", &format!("{}", out_vis_path.display()),
         "--model-filename", &format!("{}", cal_model.display()),
-        "--ignore-autos",
         "--output-vis-freq-average", &format!("{}", freq_avg_factor)
     ]);
 
@@ -274,12 +266,6 @@ fn test_1090008640_di_calibrate_writes_vis_uvfits_noautos_avg_freq() {
         gcount.parse::<usize>().unwrap(),
         exp_timesteps * exp_baselines
     );
-    // let pcount: String = get_required_fits_key!(&mut out_vis, &hdu0, "PCOUNT").unwrap();
-    // assert_eq!(pcount.parse::<usize>().unwrap(), 5);
-    // let floats_per_pol: String = get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS2").unwrap();
-    // assert_eq!(floats_per_pol.parse::<usize>().unwrap(), 3);
-    // let num_pols: String = get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS3").unwrap();
-    // assert_eq!(num_pols.parse::<usize>().unwrap(), 4);
     let num_fine_freq_chans: String =
         get_required_fits_key!(&mut out_vis, &hdu0, "NAXIS4").unwrap();
     assert_eq!(num_fine_freq_chans.parse::<usize>().unwrap(), exp_channels);

--- a/tests/integration/calibrate/mod.rs
+++ b/tests/integration/calibrate/mod.rs
@@ -400,9 +400,7 @@ pub fn test_cal_vis_output_avg_time() {
 
     let tmp_dir = TempDir::new().expect("couldn't make tmp dir").into_path();
 
-    // XXX
-    // let in_vis_path = tmp_dir.join("vis.uvfits");
-    let in_vis_path = PathBuf::from("/tmp/vis.uvfits");
+    let in_vis_path = tmp_dir.join("vis.uvfits");
 
     let phase_centre = RADec::new_degrees(0., -27.);
     let array_pos = LatLngHeight::new_mwa();

--- a/tests/integration/modelling/calibrate.rs
+++ b/tests/integration/modelling/calibrate.rs
@@ -63,6 +63,7 @@ fn test_1090008640_calibrate_model() {
         "--source-list", &srclist,
         "--outputs", &format!("{}", sols.display()),
         "--model-filename", &format!("{}", cal_model.display()),
+        "--no-progress-bars",
     ]);
 
     // Run di-cal and check that it succeeds

--- a/tests/integration/modelling/calibrate.rs
+++ b/tests/integration/modelling/calibrate.rs
@@ -229,7 +229,6 @@ fn test_1090008640_calibrate_model_ms() {
         "--source-list", &srclist,
         "--outputs", &format!("{}", sols.display()),
         "--model-filename", &format!("{}", cal_model.display()),
-        "--ignore-autos",
     ]);
 
     // Run di-cal and check that it succeeds

--- a/tests/integration/modelling/calibrate.rs
+++ b/tests/integration/modelling/calibrate.rs
@@ -63,7 +63,6 @@ fn test_1090008640_calibrate_model() {
         "--source-list", &srclist,
         "--outputs", &format!("{}", sols.display()),
         "--model-filename", &format!("{}", cal_model.display()),
-        "--ignore-autos",
     ]);
 
     // Run di-cal and check that it succeeds

--- a/tests/integration/modelling/simulate_vis.rs
+++ b/tests/integration/modelling/simulate_vis.rs
@@ -307,7 +307,6 @@ fn test_1090008640_simulate_vis_cpu_gpu_match() {
         "--output-model-file", &format!("{}", output_path.display()),
         "--num-timesteps", &format!("{}", num_timesteps),
         "--num-fine-channels", &format!("{}", num_chans),
-        "--cpu",
     ]);
     let result = simulate_vis(sim_args, true, false);
     assert!(result.is_ok(), "result={:?} not ok", result.err().unwrap());


### PR DESCRIPTION
- fix an issue when writing calibration solutions with multiple timeblocks by shortening fits key names ( https://github.com/MWATelescope/mwa_hyperdrive/pull/12/commits/16d004a42a55c9d5f5dd2b3bd578fd78069bc721 )
-  Move vis weighting outside calibration to optimize calibration performance ( https://github.com/MWATelescope/mwa_hyperdrive/pull/12/commits/5781f9a62d54bee7dfd2926f9618a61e2d266848 )
- remove autocorrelation plumbing for di cal
- implement measurement set writing for calibrated and simulated vis
- improve precision of uvfits reading
- fix logic around input and output averaging factors stacking

open questions:
- write to different columns in measurement set?