### PR TITLE
fixes #29 clarify named source filtering and invert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2025-05-13
+
+### Changed
+
+- cli args `--sources-to-subtract` and `--invert` from vis-subtract are now
+  included in all source list reading commands, behaviour is slighly different:
+    - `--sources-to-subtract` renamed to `--named-sources`
+    - `--invert` now requires `--named-sources` to be present
+
+### Fixed
+
+- [#29](https://github.com/MWATelescope/mwa_hyperdrive/issues/29) confusing syntax
+  around named source filtering and inversion.
+
 ## [0.5.1] - 2025-04-11
 
 ### Changed

--- a/src/cli/common/tests.rs
+++ b/src/cli/common/tests.rs
@@ -82,3 +82,275 @@ fn all_sources_vetoed_causes_error() {
         ReadSourceListError::NoSourcesAfterVeto
     ));
 }
+
+/// check that num-sources correctly limits the number of sources in skymodel parse
+#[test]
+fn skymodel_veto_parse_num() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    // First, verify that filtering out a nonexistent source causes the correct error.
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        num_sources: Some(3),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_ok());
+    let sl = result.unwrap();
+    assert!(sl.len() == 3);
+}
+
+/// check that named source filterng results only in the named sources
+#[test]
+fn skymodel_veto_parse_named() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    let named_sources = vec!["J002549-260211".to_string(), "J002430-292847".to_string()];
+
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        named_sources: Some(named_sources.clone()),
+        invert: Some(false),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_ok());
+    let sl = result.unwrap();
+    assert!(sl.len() == 2);
+    assert!(sl.contains_key("J002549-260211"));
+    assert!(sl.contains_key("J002430-292847"));
+}
+
+/// check that named source filterng results in everything but the named sources
+#[test]
+fn skymodel_veto_parse_named_invert() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    let named_sources = vec!["J002549-260211".to_string(), "J002430-292847".to_string()];
+
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        named_sources: Some(named_sources.clone()),
+        invert: Some(true),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_ok());
+    let sl = result.unwrap();
+    assert!(sl.len() == 98);
+    assert!(!sl.contains_key("J002549-260211"));
+    assert!(!sl.contains_key("J002430-292847"));
+}
+
+/// check that MissingSource results from nonexistent named_sources in parse_named_invert
+#[test]
+fn skymodel_veto_parse_named_invert_missing_source() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    // First, verify that filtering out a nonexistent source causes the correct error.
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        named_sources: Some(vec!["nonexistent_source".to_string()]),
+        invert: Some(false),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ReadSourceListError::MissingNamedSource { name } if name == "nonexistent_source"
+    ));
+}
+/// check that NamedSourcesAndNumSources results from --num-sources and --sources-to-subtract mismatch
+#[test]
+fn skymodel_veto_parse_named_and_num_sources() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    // First, verify that filtering out a list of sources that with a different number of sources
+    // causes the correct error.
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        num_sources: Some(3),
+        named_sources: Some(vec!["J002549-260211".to_string()]),
+        invert: Some(false),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ReadSourceListError::NamedSourcesAndNumSources { num_sources, named_sources } if num_sources == 3 && named_sources == 1
+    ));
+}
+
+/// check when --invert, --num-sources and --sources-to-subtract are all provided
+#[test]
+fn skymodel_veto_parse_named_and_num_sources_invert() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    // First, verify that filtering out a list of sources that with a different number of sources
+    // causes the correct error.
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        num_sources: Some(3),
+        named_sources: Some(vec!["J002549-260211".to_string()]),
+        invert: Some(true),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_ok());
+    let sl = result.unwrap();
+    assert!(sl.len() == 3);
+    assert!(!sl.contains_key("J002549-260211"));
+}
+
+// check that AllSourcesFiltered results from --invert and comprehensive --sources-to-subtract in parse_named_invert
+#[test]
+fn skymodel_veto_parse_named_and_num_sources_invert_all_sources() {
+    let beam = BeamArgs {
+        no_beam: true,
+        ..Default::default()
+    }
+    .parse(128, None, None, None)
+    .expect("no problems setting up a NoBeam");
+
+    let source_list = Some(
+        "test_files/1090008640/srclist_pumav3_EoR0aegean_EoR1pietro+ForA_1090008640_peel100.txt"
+            .to_string(),
+    );
+
+    // First, get the full list of source names
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        invert: Some(true),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+    assert!(result.is_ok());
+    let sl = result.unwrap();
+    assert!(sl.len() == 100);
+    let named_sources: Vec<String> = sl.keys().cloned().collect();
+
+    // now invert the full list of sources
+    let result = SkyModelWithVetoArgs {
+        source_list: source_list.clone(),
+        named_sources: Some(named_sources.clone()),
+        invert: Some(true),
+        ..Default::default()
+    }
+    .parse(
+        RADec::from_degrees(0.0, -30.0),
+        0.0,
+        MWA_LAT_RAD,
+        &[150e6],
+        &*beam,
+    );
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        ReadSourceListError::AllSourcesFiltered { invert } if invert == true
+    ));
+}

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -15,7 +15,6 @@ use super::{
     srclist::SrclistByBeamError,
     vis_convert::VisConvertArgsError,
     vis_simulate::VisSimulateArgsError,
-    vis_subtract::VisSubtractArgsError,
 };
 use crate::{
     beam::BeamError,
@@ -284,17 +283,6 @@ impl From<VisSimulateError> for HyperdriveError {
             VisSimulateError::VisWrite(e) => Self::from(e),
             VisSimulateError::Model(e) => Self::from(e),
             VisSimulateError::IO(e) => Self::from(e),
-        }
-    }
-}
-
-impl From<VisSubtractArgsError> for HyperdriveError {
-    fn from(e: VisSubtractArgsError) -> Self {
-        let s = e.to_string();
-        match e {
-            VisSubtractArgsError::MissingSource { .. }
-            | VisSubtractArgsError::NoSources
-            | VisSubtractArgsError::AllSourcesFiltered => Self::VisSubtract(s),
         }
     }
 }

--- a/src/srclist/error.rs
+++ b/src/srclist/error.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::borrow::Cow;
+
 use thiserror::Error;
 
 use crate::{
@@ -48,6 +50,20 @@ pub(crate) enum ReadSourceListError {
 
     #[error("The number of specified sources was 0, or the size of the source list was 0")]
     NoSources,
+
+    #[error("Specified source {name} is not in the input source list; can't subtract it")]
+    MissingNamedSource { name: Cow<'static, str> },
+
+    #[error("Number of sources specified {named_sources} and number of sources to use {num_sources} are not the same")]
+    NamedSourcesAndNumSources {
+        num_sources: usize,
+        named_sources: usize,
+    },
+
+    #[error(
+        "No sources were left after filtering named sources from the source list. invert={invert}"
+    )]
+    AllSourcesFiltered { invert: bool },
 
     #[error("After vetoing sources, none were left. Decrease the veto threshold, or supply more sources")]
     NoSourcesAfterVeto,

--- a/tests/integration_tests/no_stderr.rs
+++ b/tests/integration_tests/no_stderr.rs
@@ -150,7 +150,6 @@ fn test_vis_simulate_and_vis_subtract_no_stderr() {
             "vis-subtract",
             "--data", &metafits, &format!("{}", model_path.display()),
             "--source-list", &srclist,
-            "--invert",
             "--output", &format!("{}", sub_path.display()),
             "--no-progress-bars"
         ])


### PR DESCRIPTION
cli args `--sources-to-subtract` and `--invert` from vis-subtract are now included in all source list reading commands, behaviour is slighly different:
 - `--sources-to-subtract` renamed to `--named-sources`
 - `--invert` now requires `--named-sources` to be present