### PR TITLE
fix(mdbook): pin mdbook versions and fix config

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -16,8 +16,10 @@ jobs:
           profile: minimal
       - name: Install mdBook
         run: |
-          (test -x $HOME/.cargo/bin/mdbook || cargo install mdbook)
-          cargo install mdbook-linkcheck mdbook-mermaid mdbook-admonish
+          (test -x $HOME/.cargo/bin/mdbook || cargo install mdbook --version 0.4.40)
+          cargo install mdbook-linkcheck --version 0.7.7
+          cargo install mdbook-mermaid --version 0.13.0
+          cargo install mdbook-admonish --version 1.16.0
       - name: Build and Test
         run: |
           cd mdbook

--- a/mdbook/book.toml
+++ b/mdbook/book.toml
@@ -3,8 +3,6 @@ title = "mwa_hyperdrive documentation"
 authors = ["Christopher H. Jordan", "Dev Null"]
 description = "mwa_hyperdrive documentation"
 language = "en"
-multilingual = false
-
 [output.html]
 mathjax-support = true
 git-repository-url = "https://github.com/MWATelescope/mwa_hyperdrive"


### PR DESCRIPTION
- Removed unsupported `multilingual` config from book.toml
- Pinned mdbook to 0.4.40 to ensure compatibility with theme and plugins
- Pinned plugins versions (admonish 1.16.0, mermaid 0.13.0, linkcheck 0.7.7) EOF